### PR TITLE
boot fix for slow devices without udev using LABELS

### DIFF
--- a/init_functions
+++ b/init_functions
@@ -332,7 +332,14 @@ resolve_device() {
     # USB, which might not immediately show up.
     case $device in
         UUID=*|LABEL=*|PARTUUID=*|PARTLABEL=*)
-            dev=$(blkid -lt "$device" -o device)
+            # if udev is running then try once
+            # if udev is not running try for (timeout * sleep =) 5 seconds to handle slow (USB) devices
+            [ "$udevd_running" -eq 1 ] && timeout=1 || timeout=20
+            while [ $timeout -gt 0 ]; do
+                timeout=$((timeout - 1))
+                dev=$(blkid -lt "$device" -o device)
+                [ -n "$dev" ] && timeout=0 || sleep 0.25
+            done
             if [ -z "$dev" -a "$udevd_running" -eq 1 ]; then
                 dev=$(tag_to_udev_path "${device%%=*}" "${device#*=}")
             fi


### PR DESCRIPTION
Optimized bootups according to http://blog.falconindy.com/articles/optmizing-bootup-with-mkinitcpio.html and https://wiki.archlinux.org/index.php/Minimal_initramfs#Udev_requirement might end up without the mkinitcpio udev hook. As a result the initramfs resolve_device() function will only be called once. 

Not ultra fast devices (CPU, USB flash memory) or BTRFS might not yet be able to map labels (UUID, LABEL, PARTUUID, PARTLABEL) to a device, yet. That may take a few seconds. As a result initramfs is not being able to find the root device and errors out in the emergency shell. This fix will retry up to 5 seconds when udev is not running.

Tested on Intel DE3815TYKE with Samsung MUF-32BB flash drive and btrfs.